### PR TITLE
ability to use alternate ports and a basic docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ certs/*.pem
 certs/*.csr
 certs/*.srl
 certs/*.crt
+
+.idea
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:latest
+
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY certs /home/ca

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,36 @@
 %: all
 
+DOCKER_REPO=
+DOCKER_TAG ?= $(shell git describe --always --dirty)
+
 .PHONY: all
 all:
 	make -C ./certs all
+	make -C ./nginx all
 
 .PHONY: nginx
 nginx: all
 	docker run -p 80:80 -p 443:443  -v `pwd`/nginx/nginx.conf:/etc/nginx/nginx.conf -v `pwd`/certs:/home/ca --rm nginx:latest
+
+.PHONY: docker-build
+docker-build: docker-vars all
+	@echo "Building Docker image: $(DOCKER_REPO):$(DOCKER_TAG)"
+	docker build -f Dockerfile -t $(DOCKER_REPO):$(DOCKER_TAG) .
+
+.PHONY: docker-push
+docker-push: docker-build
+	@echo "Pushing Docker image: $(DOCKER_REPO):$(DOCKER_TAG)"
+	docker push $(DOCKER_REPO):$(DOCKER_TAG)
+
+.PHONY: docker-run
+docker-run: docker-vars
+	docker run -it --rm \
+	  --name aia-milkyway \
+	  --network host \
+	  $(DOCKER_REPO):$(DOCKER_TAG)
+
+docker-vars:
+	test -n "$(DOCKER_REPO)" # $$DOCKER_REPO
 
 .PHONY: clean
 clean:

--- a/certs/Makefile
+++ b/certs/Makefile
@@ -1,5 +1,16 @@
 %: all
 
+CA_PORT ?= 80
+CONFIGS := int_ca_config int1_ca_config www.milkyway.com_config
+
+.PHONY: configs
+configs: $(CONFIGS)
+
+.PHONY: $(CONFIGS)
+$(CONFIGS):
+	@test $(CA_PORT) -ne 80 && sed -i '' -E "s#http://ca.milkyway.com/#http://ca.milkyway.com:$(CA_PORT)/#" $@ || true
+	@test $(CA_PORT) -eq 80 && sed -i '' -E "s#http://ca.milkyway.com:[0-9]+/#http://ca.milkyway.com/#" $@ || true
+
 root_ca.key.pem:
 	openssl genrsa -des3 -out root_ca.key.pem 2048
 
@@ -36,7 +47,7 @@ www.milkyway.com.cert.pem: www.milkyway.com.key.pem int_ca.cert.pem int1_ca.cert
 	cat www.milkyway.com.cert.pem int1_ca.cert.pem > www.milkyway.com.bad.chain.pem
 
 .PHONY: all
-all: root_ca.cert.pem int_ca.cert.pem int1_ca.cert.pem www.milkyway.com.cert.pem
+all: configs root_ca.cert.pem int_ca.cert.pem int1_ca.cert.pem www.milkyway.com.cert.pem
 
 .PHONY: clean
 clean:

--- a/nginx/Makefile
+++ b/nginx/Makefile
@@ -1,0 +1,16 @@
+%: all
+
+CA_PORT ?= 80
+TLS_PORT ?= 443
+CONFIGS := nginx.conf
+
+.PHONY: configs
+configs: $(CONFIGS)
+
+.PHONY: $(CONFIGS)
+$(CONFIGS):
+	@sed -i '' -E '/# CA server/{n;s/listen.*;/listen       $(CA_PORT);/;}' $@
+	@sed -i '' -E '/# www.milkyway.com/{n;s/listen.*;/listen       $(TLS_PORT) ssl;/;}' $@
+
+.PHONY: all
+all: configs


### PR DESCRIPTION
Happened across this repo a few days ago while troubleshooting an AIA issue, and it was very helpful – thank you!

The troubleshooting session required that the AIA endpoint to be running with non-standard ports and a remote Docker host.

Figured I'd submit this PR in case it might be helpful ... 

